### PR TITLE
Update shot.py

### DIFF
--- a/src/renderer/layers/shot.py
+++ b/src/renderer/layers/shot.py
@@ -115,9 +115,12 @@ class LayerShotBase(LayerBase):
                     ]
                 except KeyError:
                     atba = []
-                main = self._ships[spid]["components"][scomp["artillery"]][
-                    "ammo_list"
-                ]
+                try:
+                    main = self._ships[spid]["components"][scomp["artillery"]][
+                        "ammo_list"
+                    ]
+                except KeyError:
+                    main = []
                 is_secondary = params_id in atba
                 is_secondary = params_id not in main
 


### PR DESCRIPTION
Bug fix:
- secondaries would not show for ships without main battery gun ammo_list defined.