### PR TITLE
feat: add mappings for assist ribbon in solo maps

### DIFF
--- a/src/renderer/layers/ribbon.py
+++ b/src/renderer/layers/ribbon.py
@@ -24,6 +24,7 @@ SOLO_MAP = {
     27: "splane",
     31: "dbomb",
     33: "drop",
+    54: "assist",
 }
 
 

--- a/src/renderer/versions/14_11_0/layers/ribbon.py
+++ b/src/renderer/versions/14_11_0/layers/ribbon.py
@@ -24,6 +24,7 @@ SOLO_MAP = {
     33: "drop",
     46: "demining_mine",
     47: "demining_minefield",
+    54: "assist",
 }
 
 


### PR DESCRIPTION
Add assist ribbon to ribbon layer (bottom right)

<img width="552" height="316" alt="image" src="https://github.com/user-attachments/assets/c3c7821d-45da-4101-9c95-3679332bcfa1" />
